### PR TITLE
feat: decommissioned title & status code

### DIFF
--- a/decommissioned-site/Dockerfile
+++ b/decommissioned-site/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:stable-alpine
 
 ENV NGINX_ENVSUBST_TEMPLATE_DIR=/usr/share/nginx/templates
 ENV NGINX_ENVSUBST_OUTPUT_DIR=/usr/share/nginx/html
-ENV DECOMMISSION_TITLE="Website has been permanently discontinued"
+ENV DECOMMISSION_TITLE="Decommissioned website"
 ENV DECOMMISSION_NOTICE="This site has been decommissioned."
 
 COPY . /

--- a/decommissioned-site/Dockerfile
+++ b/decommissioned-site/Dockerfile
@@ -2,6 +2,7 @@ FROM nginx:stable-alpine
 
 ENV NGINX_ENVSUBST_TEMPLATE_DIR=/usr/share/nginx/templates
 ENV NGINX_ENVSUBST_OUTPUT_DIR=/usr/share/nginx/html
+ENV DECOMMISSION_TITLE="Website has been permanently discontinued"
 ENV DECOMMISSION_NOTICE="This site has been decommissioned."
 
 COPY . /

--- a/decommissioned-site/README.md
+++ b/decommissioned-site/README.md
@@ -1,6 +1,6 @@
 # Decommissioned site
 
-NGINX Docker image which always responds with 200 static HTML content.
+NGINX Docker image which always responds with 410 static HTML content.
 
 Intended to inform users about decommmisioned services.
 
@@ -12,6 +12,14 @@ Example:
 
 ```
 ENV DECOMMISSION_NOTICE="This site has been decommissioned.</br>Find out more at <a href=\"https://www.europeana.eu\">Europeana.eu</a>."
+```
+
+Additionally the page title & heading can be modified by setting an ENV value for `DECOMMISSION_TITLE`.
+
+Example:
+
+```
+ENV DECOMMISSION_TITLE="Decommissioned | website"
 ```
 
 ## Build

--- a/decommissioned-site/README.md
+++ b/decommissioned-site/README.md
@@ -19,7 +19,7 @@ Additionally the page title & heading can be modified by setting an ENV value fo
 Example:
 
 ```
-ENV DECOMMISSION_TITLE="Decommissioned | website"
+ENV DECOMMISSION_TITLE="Decommissioned website"
 ```
 
 ## Build

--- a/decommissioned-site/etc/nginx/conf.d/default.conf
+++ b/decommissioned-site/etc/nginx/conf.d/default.conf
@@ -3,8 +3,10 @@ server {
     listen  [::]:80;
     server_name  localhost;
 
+    error_page 410 /index.html;
+
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/ =410;
     }
 
     location ~/index\.html {

--- a/decommissioned-site/usr/share/nginx/templates/index.html.template
+++ b/decommissioned-site/usr/share/nginx/templates/index.html.template
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Service Unavailable</title>
+    <title>${DECOMMISSION_TITLE}</title>
     <style>
       html { color-scheme: light dark; }
       body { width: 35em; margin: 0 auto; font-family: Tahoma, Verdana, Arial, sans-serif; }
     </style>
   </head>
   <body>
-    <h1>Service Unavailable</h1>
+    <h1>${DECOMMISSION_TITLE}</h1>
     <p>${DECOMMISSION_NOTICE}</p>
   </body>
 </html>


### PR DESCRIPTION
Allows setting the page title via setting `DECOMMISSION_TITLE`
Decommissioned sites return html page with a 410 (Gone) status code.
